### PR TITLE
allow execution even if there are no inputs

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-router-dom": "^5.2.0",
+    "react-tooltip": "^4.2.10",
     "shortid": "^2.2.15"
   },
   "devDependencies": {
@@ -30,7 +31,7 @@
     "@types/react-dom": "^16.9.0",
     "@types/react-router-dom": "^5.1.5",
     "@types/shortid": "0.0.29",
-    "react-scripts": "3.4.1",
+    "react-scripts": "^3.4.3",
     "typescript": "~3.7.2"
   },
   "eslintConfig": {

--- a/src/components/ContractMemberForm.tsx
+++ b/src/components/ContractMemberForm.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import ReactTooltip from "react-tooltip";
 import { useWeb3React } from '@web3-react/core';
 import { generate } from 'shortid';
 import { FullContractWrapper } from '../types';
@@ -28,10 +29,6 @@ export const ContractMemberForm = (props: ContractMemberFormProps) => {
         setInputValues(values);
     // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
-
-    if (props.inputs?.length === 0) {
-        return <></>
-    }
 
     function handleChange(event: any) {
         if (!inputValues) return;
@@ -80,18 +77,22 @@ export const ContractMemberForm = (props: ContractMemberFormProps) => {
         </div>
     )
 
-    let executeButton = <></>
-    if (context.account || props.readOnly) {
-        executeButton = 
-            <div className="form-group row">
-                <label className="col-sm-2 col-form-label" />
-                <div className="col-sm-10">
-                    <button type="button" className="btn btn-info btn-sm" onClick={onExecuteMember}>
+    let isExecuteDisabled = !(context.account || props.readOnly);
+
+    let executeButton =
+        <div className="form-group row">
+            <label className="col-sm-2 col-form-label"/>
+            <div className="col-sm-10">
+                <span data-tip={"connect you web3 account"} data-tip-disable={!isExecuteDisabled}>
+                    <button type="button" className="btn btn-info btn-sm" onClick={onExecuteMember}
+                            disabled={isExecuteDisabled}>
                         execute
                     </button>
-                </div>
+                </span>
+                <ReactTooltip place="top" type="dark" effect="float"/>
             </div>
-    }
+        </div>
+
 
     let renderOutput = <></>
     if (output) { 


### PR DESCRIPTION
Hello, I was looking at the issue #3 and I took a shoot at resolving it. 

* the execution panel will show even if there are no inputs
* the execute button will be disabled if there is no account connected for the function and a tooltip will shown. 

disabled:
![image](https://user-images.githubusercontent.com/1120692/94338807-6da7b800-fff5-11ea-8dfb-87bf96902ec7.png)

enabled
![image](https://user-images.githubusercontent.com/1120692/94338817-7ef0c480-fff5-11ea-9785-cb7216c24a5c.png)

nice tool btw! regards. 